### PR TITLE
Indentation tweaks, fix prismJS language highlighting keywords in JSON

### DIFF
--- a/docs/fundamentals/cast.md
+++ b/docs/fundamentals/cast.md
@@ -48,8 +48,8 @@ A simple, hello world message from the user `@v` might look like this:
 ```javascript
 {
   body: {
-    username: 'v',
     address: '0x6bFBF67473014Bfd814BCAF9259f5EB41A48380A',
+    username: 'v',
     publishedAt: 1622579480955,
     type: 'text-short',
     data: {

--- a/docs/fundamentals/cast.md
+++ b/docs/fundamentals/cast.md
@@ -17,14 +17,14 @@ A determined, malicious user who hates the sound of `gif` might rewrite all thei
 
 The cast object looks like this: 
 
-```tsx
+```javascript
 interface Cast {
   body: {
 	  address: string;
 	  username: string;
 	  publishedAt: number; 
 	  type: string;
-		data: unknown;	
+	  data: unknown;	
 	  sequence: number;
 	  prevMerkleRoot: string;
   },
@@ -35,8 +35,8 @@ interface Cast {
 
 A cast is a [signed blob](https://www.notion.so/Signed-Blob-d6f35b95dd4946e0a208441996612ce4), so it follows the typical structure of having a `body`, `merkleRoot` and `signature`.  The body object contains a few new properties: 
 
-- `username` -  the user who generated  the cast.
 - `address` - the Ethereum that signed the cast.
+- `username` -  the user who generated  the cast.
 - `publishedAt` - the unverified, user-reported unix timestamp of publication.
 - `type` - the schema for message in the data object.
 - `data`- the message that the user is broadcasting as defined by the type schema.
@@ -45,14 +45,14 @@ A cast is a [signed blob](https://www.notion.so/Signed-Blob-d6f35b95dd4946e0a208
 
 A simple, hello world message from the user `@v` might look like this:
 
-```tsx
+```javascript
 {
   body: {
     username: 'v',
     address: '0x6bFBF67473014Bfd814BCAF9259f5EB41A48380A',
     publishedAt: 1622579480955,
     type: 'text-short',
-		data: {
+    data: {
       text: 'hello world!',
     },
     sequence: 0,
@@ -71,10 +71,10 @@ A simple, hello world message from the user `@v` might look like this:
 Farcaster defines the `text-short` schema which is used in its social network. It allows short simple text messages that can either stand alone, or be replies to other messages.  It defines the cast data as an object that contains two properties: 
 
 ```tsx
-		data: {
-		  text: string;
-			replyParentMerkleRoot?: string;
-		}
+data: {
+  text: string;
+  replyParentMerkleRoot?: string;
+}
 ```
 
 - `text` - the message from the user, which may contain up to 280 unicode characters

--- a/docs/fundamentals/signed-blob.md
+++ b/docs/fundamentals/signed-blob.md
@@ -15,11 +15,11 @@ You can think of a signed blob as an interface that all data stored on the host 
 
 ```json
 {
-	"body":  {
-    "text": "Hello, world!"
-	},
-	"merkleRoot": "0xfoo",
-	"signature": "0xbar"
+    "body":  {
+        "text": "Hello, world!"
+    },
+    "merkleRoot": "0xfoo",
+    "signature": "0xbar"
 }
 ```
 


### PR DESCRIPTION
These are minor, visual improvements (I am OCD about this stuff and it bothered me when I went over the docs). I fixed the alignment for some keys in the JSON data objects (see screenshots before/after 1 and 2) and changed the syntax highlighting (prismJS lib) from tsx to javascript, which stop highlighting `type` (a typescript keyword that it mistakenly thinks should be highlighted) in the JSON blobs (see screenshots below)


Before
<img width="1014" alt="Screen Shot 2022-02-22 at 3 52 07 PM" src="https://user-images.githubusercontent.com/1666947/155239419-d8aaed3d-5514-4f17-b6b2-964a220fb626.png">

After
<img width="1002" alt="Screen Shot 2022-02-22 at 3 52 19 PM" src="https://user-images.githubusercontent.com/1666947/155239444-fbb78817-edb9-4d3f-a29f-3dd3bb292b63.png">

