### PR TITLE
Update links to use a static URL

### DIFF
--- a/src/pages/download.tsx
+++ b/src/pages/download.tsx
@@ -34,13 +34,13 @@ function DownloadPage() {
           <h5>Desktop</h5>
           <Link
             className={styles.downloadButton}
-            to="https://s3.amazonaws.com/release.reader.merklemanufactory.com/Farcaster-0.4.29.dmg"
+            to="https://s3.amazonaws.com/release.reader.merklemanufactory.com/Farcaster-latest.dmg"
           >
             macOS - Intel
           </Link>
           <Link
             className={styles.downloadButton}
-            to="https://s3.amazonaws.com/release.reader.merklemanufactory.com/Farcaster-0.4.29-arm64.dmg"
+            to="https://s3.amazonaws.com/release.reader.merklemanufactory.com/Farcaster-latest-arm64.dmg"
           >
             macOS - Apple silicon
           </Link>


### PR DESCRIPTION
This will be updated every time we publish, so we don't need to update these links here.
