### PR TITLE
docs: add write-data example

### DIFF
--- a/docs/developers/examples.md
+++ b/docs/developers/examples.md
@@ -17,3 +17,21 @@ On your local machine, go through the following steps:
 :::info
 Replace the FIDs at the top of the file with yours to see your messages.
 :::
+
+## Update your profile picture
+
+On your local machine, go through the following steps:
+
+1. Check out [hub-monorepo](https://github.com/farcasterxyz/hub-monorepo) to your local machine.
+
+2. Navigate to the `packages/hub-nodejs/examples/write-data` directory.
+
+3. Install dependencies with `yarn install` or `npm install`.
+
+4. Update `MNEMONIC` and `FID` at the top of the file with your own.
+
+5. Run `yarn start` or `npm start` .
+
+:::info
+write-data broadcasts to testnet by default, but provides instructions to submit to mainnet
+:::


### PR DESCRIPTION
Add an example for writing data by showing users how to update their profile picture on a testnet hub.