### PR TITLE
docs: add make-cast example

### DIFF
--- a/docs/developers/examples.md
+++ b/docs/developers/examples.md
@@ -35,3 +35,21 @@ On your local machine, go through the following steps:
 :::info
 write-data broadcasts to testnet by default, but provides instructions to submit to mainnet
 :::
+
+## Publish new casts
+
+On your local machine, go through the following steps:
+
+1. Check out [hub-monorepo](https://github.com/farcasterxyz/hub-monorepo) to your local machine.
+
+2. Navigate to the `packages/hub-nodejs/examples/make-cast` directory.
+
+3. Install dependencies with `yarn install` or `npm install`.
+
+4. Update `MNEMONIC` and `FID` at the top of the file with your own.
+
+5. Run `yarn start` or `npm start` .
+
+:::info
+make-cast broadcasts to testnet by default, but provides instructions to submit to mainnet
+:::


### PR DESCRIPTION
Add examples to create different types of casts

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds instructions for publishing new casts to the `hub-monorepo` and provides information on how to submit to the mainnet. 

### Detailed summary
- Added instructions for publishing new casts to the `hub-monorepo`
- Provided steps for running `make-cast` and updating `MNEMONIC` and `FID` with your own values
- Broadcasts to testnet by default, but now includes instructions for submitting to mainnet.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->