### PR TITLE
docs: add replicate to postgres example

### DIFF
--- a/docs/developers/examples.md
+++ b/docs/developers/examples.md
@@ -36,6 +36,16 @@ On your local machine, go through the following steps:
 write-data broadcasts to testnet by default, but provides instructions to submit to mainnet
 :::
 
+## Replicate data to Postgres DB
+
+On your local machine, go through the following steps:
+
+1. Check out [hub-monorepo](https://github.com/farcasterxyz/hub-monorepo) to your local machine.
+
+2. Navigate to the `packages/hub-nodejs/examples/replicate-data-postgres` directory.
+
+3. Follow the instructions in README.md
+
 ## Publish new casts
 
 On your local machine, go through the following steps:


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds instructions for replicating data to a Postgres DB in the examples.md file and updates the README.md file for publishing new casts.

### Detailed summary
- Added instructions for replicating data to a Postgres DB in `docs/developers/examples.md`
- Updated the README.md file for publishing new casts on a local machine.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->