### PR TITLE
docs: Improve documentation for fnames

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -43,6 +43,7 @@ export default defineConfig({
           { text: 'Overview', link: '/protocol/overview' },
           { text: 'Concepts', link: '/protocol/concepts' },
           { text: 'Architecture', link: '/protocol/architecture' },
+          { text: 'Fnames', link: '/protocol/fnames' },
           { text: 'Messages', link: '/protocol/messages' },
           { text: 'Governance', link: '/protocol/governance' },
           { text: 'FIPs', link: '/protocol/fips' },

--- a/docs/protocol/architecture.md
+++ b/docs/protocol/architecture.md
@@ -72,23 +72,7 @@ Users can associate ENS names with their accounts making it easy for others to m
 
 Farcaster supports two kinds of ENS names today:
 
-- **fnames**, which are free and governed by farcaster.
+- [**fnames**](./fnames.md), which are free and governed by farcaster.
 - **.eth names**, which cost money and are user-controlled.
 
 ![Usernames](../assets/usernames.png)
-
-### Fnames
-
-Farcaster issues offchain ENS names under the `fcast.id`. A user can register `bob.fcast.id` and use it as `@bob` in supported Farcaster apps. Registering a name requires a signed message from an account that does not own an fname. Registrations are handled by the Fname Registry server and the Fname Resolver, implemented according to [ENSIP-16](https://docs.ens.domains/ens-improvement-proposals/ensip-16-offchain-metadata) and [ERC-3668](https://eips.ethereum.org/EIPS/eip-3668).
-
-### Fname Policy
-
-Fnames have a usage policy to prevent squatting and impersonation. Users who do not want to be subject to the policy can register .eth names which are user controlled. The fname policy has two tenets: 
-
-- Names connected to public figures or entities may be reclaimed (e.g. @google)
-- Names that haven't been used for 60+ days may be reclaimed
-
-Decisions usually require human judgementand are made by the Farcaster core team. For instance, if a user registers @elon and Elon Musk wants the name, we made the decision based on whether the user:
-
-- Is active and creating quality content on Farcaster
-- Has a reasonable claim, like being called elon or owning the handle elsewhere

--- a/docs/protocol/fips.md
+++ b/docs/protocol/fips.md
@@ -9,15 +9,17 @@ An FIP, or Farcaster Improvement Proposal, is a process for building consensus a
 Read more about FIP's in [FIP-0: A proposal for making proposals](https://github.com/farcasterxyz/protocol/discussions/82). A list of finalized proposals can be found below. Proposals are made and ratified on the [discussions board](https://github.com/farcasterxyz/protocol/discussions/categories/fip-stage-4-finalized).
 
 
-| FIP | Title                                                                                      | Authors                        |
-|-----|--------------------------------------------------------------------------------------------|--------------------------------|
-| 0   | [A proposal for making proposals](https://github.com/farcasterxyz/protocol/discussions/82) | @v                             |
-| 1   | [Canonical URIs](https://github.com/farcasterxyz/protocol/discussions/72)                  | @pfh, @v                       |
-| 2   | [Flexible targets for messages](https://github.com/farcasterxyz/protocol/discussions/71)   | @pfh                           |
-| 3   | [Links](https://github.com/farcasterxyz/protocol/discussions/85)                           | @cassie, @v                    |
-| 4   | [ENS Usernames](https://github.com/farcasterxyz/protocol/discussions/90)                   | @horsefacts, @sanjay, @sds, @v |
-| 5   | [Instant Recovery](https://github.com/farcasterxyz/protocol/discussions/100)               | @v                             |
-| 6   | [Flexible Storage](https://github.com/farcasterxyz/protocol/discussions/98)                | @cassie, @horsefacts, @v       |
-| 7   | [Onchain Signers](https://github.com/farcasterxyz/protocol/discussions/103)                | @horsefacts, @sanjay, @v       |
+| FIP | Title                                                                                          | Authors                        |
+|-----|------------------------------------------------------------------------------------------------|--------------------------------|
+| 0   | [A proposal for making proposals](https://github.com/farcasterxyz/protocol/discussions/82)     | @v                             |
+| 1   | [Canonical URIs](https://github.com/farcasterxyz/protocol/discussions/72)                      | @pfh, @v                       |
+| 2   | [Flexible targets for messages](https://github.com/farcasterxyz/protocol/discussions/71)       | @pfh                           |
+| 3   | [Links](https://github.com/farcasterxyz/protocol/discussions/85)                               | @cassie, @v                    |
+| 4   | [ENS Usernames](https://github.com/farcasterxyz/protocol/discussions/90)                       | @horsefacts, @sanjay, @sds, @v |
+| 5   | [Instant Recovery](https://github.com/farcasterxyz/protocol/discussions/100)                   | @v                             |
+| 6   | [Flexible Storage](https://github.com/farcasterxyz/protocol/discussions/98)                    | @cassie, @horsefacts, @v       |
+| 7   | [Onchain Signers](https://github.com/farcasterxyz/protocol/discussions/103)                    | @horsefacts, @sanjay, @v       |
+| 8   | [Verifications for Contract Wallets](https://github.com/farcasterxyz/protocol/discussions/109) | @horsefacts, @sanjay, @eulerlagrange.eth       |
+| 9   | [Globally Unique Verifications](https://github.com/farcasterxyz/protocol/discussions/114)      | @sanjay, @v       |
 
 

--- a/docs/protocol/fnames.md
+++ b/docs/protocol/fnames.md
@@ -1,0 +1,125 @@
+# Fnames
+
+Farcaster issues offchain ENS names under the `fcast.id`. A user can register `bob.fcast.id` and use it as `@bob` in supported Farcaster apps. Registering a name requires a signed message from an account that does not own an fname. Registrations are handled by the Fname Registry server and the Fname Resolver, implemented according to [ENSIP-16](https://docs.ens.domains/ens-improvement-proposals/ensip-16-offchain-metadata) and [ERC-3668](https://eips.ethereum.org/EIPS/eip-3668).
+
+## Fname Policy
+
+Fnames have a usage policy to prevent squatting and impersonation. Users who do not want to be subject to the policy can register .eth names which are user controlled. The fname policy has two tenets:
+
+- Names connected to public figures or entities may be reclaimed (e.g. @google)
+- Names that haven't been used for 60+ days may be reclaimed
+
+Decisions usually require human judgementand are made by the Farcaster core team. For instance, if a user registers @elon and Elon Musk wants the name, we made the decision based on whether the user:
+
+- Is active and creating quality content on Farcaster
+- Has a reasonable claim, like being called elon or owning the handle elsewhere
+
+
+## API
+
+The [Fname registry](https://github.com/farcasterxyz/fname-registry) server is hosted at https://fnames.farcaster.xyz
+
+It's a simple HTTP service that's responsible for issuing and tracking fnames. All fname changes are recorded as a transfer.
+Registering an Fname is a transfer from fid 0 to the user's fid. Transferring an fname is a transfer from the user's fid to another fid. Unregistering an fname is a transfer from the user's fid to fid 0.
+
+### Get Transfer History
+
+To get a history of all transfers, make a GET request to `/transfers` 
+
+```bash
+curl https://fnames.farcaster.xyz/transfers | jq
+```
+
+It also accepts the following query parameters:
+ - `from_id` - The transfer id to start from for pagination
+ - `name` - The fname to filter by
+ - `fid` - The fid (either from or to) to filter by
+ - `from_ts` - The timestamp (in seconds) to start from for pagination
+
+### Get current fname or fid
+
+To get the most recent transfer event for an fid or fname, make a GET request to `/transfers/current`
+
+e.g. To determine the fid of `@farcaster`, make the following call and use the value from the `to` field in the return value
+```bash
+curl https://fnames.farcaster.xyz/transfers?name=farcaster | jq
+```
+
+To determine the fname of fid `1`, make the following call and use the value from the `username` field in the return value
+```bash
+curl https://fnames.farcaster.xyz/transfers?fid=1 | jq
+```
+
+Both will return the same transfer object:
+```json
+{
+  "transfer": {
+    "id": 1,
+    "timestamp": 1628882891,
+    "username": "farcaster",
+    "owner": "0x8773442740c17c9d0f0b87022c722f9a136206ed",
+    "from": 0,
+    "to": 1,
+    "user_signature": "0xa6fdd2a69deab5633636f32a30a54b21b27dff123e6481532746eadca18cd84048488a98ca4aaf90f4d29b7e181c4540b360ba0721b928e50ffcd495734ef8471b",
+    "server_signature": "0xb7181760f14eda0028e0b647ff15f45235526ced3b4ae07fcce06141b73d32960d3253776e62f761363fb8137087192047763f4af838950a96f3885f3c2289c41b"
+  }
+}
+```
+
+### Register or transfer an fname
+
+To register a new fid, e.g. `hubble`, first make sure the fname is not already registered.
+
+Then make a POST request to `/transfers` with the following body:
+
+```yaml
+{
+  "name": "hubble", // Name to register
+  "from": 0,  // Fid to transfer from (0 for a new registration)
+  "to": 123, // Fid to transfer to (0 to unregister)
+  "fid": 123, // Fid making the request (must match from or to)
+  "owner": "0x...", // Custody address of fid making the request
+  "timestamp": 1641234567,  // Current timestamp in seconds
+  "signature": "0x..."  // EIP-712 signature signed by the custody address of the fid
+}
+```
+
+To generate the EIP-712 signature, use the following code:
+
+```js
+import { ethers } from 'ethers';
+const signer: ethers.Signer = undefined // Signer for the custody address
+
+const domain = {
+    name: 'Farcaster name verification',
+    version: '1',
+    chainId: 1,
+    verifyingContract: '0xe3be01d99baa8db9905b33a3ca391238234b79d1',
+};
+
+const types = {
+    UserNameProof: [
+        { name: 'name', type: 'string' },
+        { name: 'timestamp', type: 'uint256' },
+        { name: 'owner', type: 'address' },
+    ],
+};
+
+const userNameProof = {
+    name: 'hubble',
+    timestamp: 1641234567,
+    owner: '0x...',
+}
+
+const signature = await signer.signTypedData(domain, types, userNameProof)
+```
+This is the exact same kind of signature used in the ENS UsernameProofs provided to hubs to prove ownership of an ENS name.
+
+
+e.g.
+```bash
+curl -X POST https://fnames.farcaster.xyz/transfers \
+  -H "Content-Type: application/json" \
+  -d \
+'{"name": "hubble", "owner": "0x...", "signature": "0x...", "from": 0, "to": 1000, "timestamp": 1641234567, fid: 1000}'
+```


### PR DESCRIPTION
Improve documentation on how to query for and register fnames

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds support for Fnames in the Farcaster protocol. Fnames are offchain ENS names issued by Farcaster that can be registered and used in Farcaster apps.

### Detailed summary
- Added `Fnames` to the navigation menu in the documentation
- Updated the `Architecture` page to include a link to the `Fnames` page
- Added a new `Fnames` page with information on Fnames and their policy
- Added an API section to the `Fnames` page with details on the Fname registry server API
- Added examples and instructions for using the Fname registry server API

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->