### PR TITLE
Website grammer mods

### DIFF
--- a/docs/protocol/architecture.md
+++ b/docs/protocol/architecture.md
@@ -56,11 +56,11 @@ When a message is received, it is hashed, and its signature is compared against 
 
 ### Storage
 
-When a message is validated, it is stored in a message set. Each message type has a set which defines rules for merging messages and handling cases where the number of messages exceeds the user's limits. Typically, the earliest message ends up discarded. The rules designed so that messages added in any order will always produce the same set.
+When a message is validated, it is stored in a message set. Each message type has a set which defines rules for merging messages and handling cases where the number of messages exceeds the user's limits. Typically, the earliest message ends up discarded. The rules are designed so that messages added in any order will always produce the same set.
 
 ### Replication 
 
-When a message is stored, it is sent to other hubs over a libp2p gossip mesh. Messages that do not arrive over gossip are fetched using diff sync, a periodic out-of-band process. Diff sync compares the merkle trie of messages ids between two hubs and fetches missing messages. Hubs monitor peers and score their behavior. If a peer doesn't accept valid messages, falls behind or gossips too much, it may be ignored by its peers.
+When a message is stored, it is sent to other hubs over a libp2p gossip mesh. Messages that do not arrive over gossip are fetched using diff sync, a periodic out-of-band process. Diff sync compares the merkle tree of message ids between two hubs and fetches any missing messages. Hubs monitor peers and score their behavior. If a peer doesn't accept valid messages, falls behind, or gossips too much it may be ignored by its peers.
 
 ### Implementations
 

--- a/docs/protocol/architecture.md
+++ b/docs/protocol/architecture.md
@@ -46,7 +46,7 @@ For more details and documentation, please see the [contracts repository](https:
 
 Hubs validate, store, and replicate account messages to other hubs. Apps run hubs to read and write to Farcaster in real-time. Hubs run on commodity hardware and are conceptually like low-level, high-performance data streams. Most apps should copy hub data into a database for easy indexing and querying. 
 
-Each hub stores the entire global state or messages created by every account on the network. The Storage Registry's max storage unit limit ensures that the size of the global state is bounded. Unlike Ethereum nodes, hubs are eventually consistent and may get messages out of order. This makes reading and writing very fast at the cost of more complexity when interpreting changes.
+Each hub stores the entire global state, i.e. all messages created by every account on the network. The Storage Registry's max storage unit limit ensures that the size of the global state is bounded. Unlike Ethereum nodes, hubs are eventually consistent and may get messages out of order. This makes reading and writing very fast at the cost of more complexity when interpreting changes.
 
 ![Hub](../assets/hub.png)
 

--- a/docs/protocol/architecture.md
+++ b/docs/protocol/architecture.md
@@ -26,7 +26,7 @@ The Id Registry issues new Farcaster accounts to Ethereum addresses. A user can 
 
 ### Storage Registry
 
-The Storage Registry rents out storage units to accounts for a yearly fee. Accounts must have at least one storage unit to publish messages on Farcaster. Storage prices are set by the contract in USD but must be paid in ETH. A Chainlink oracle determines the exchange rate which is updated at most once in 24 hours. The price, exchange rate, available units and size of each unit are controlled by Farcaster and changed based on supply and demand. 
+The Storage Registry rents out storage units to accounts for a yearly fee. Accounts must have at least one storage unit to publish messages on Farcaster. Storage prices are set by the contract in USD but must be paid in ETH. A Chainlink oracle determines the exchange rate which is updated at most once in 24 hours. The price, exchange rate, available units and size of each unit are controlled by Farcaster and vary based on supply and demand. 
 
 ### Key Registry
 
@@ -44,7 +44,7 @@ For more details and documentation, please see the [contracts repository](https:
 
 ## Hubs 
 
-Hubs validate, storage and replicate account messages to other hubs. Apps run hubs to read and write to Farcaster in real-time. Hubs run on commodity hardware and are conceptually like low-level, high-performance data streams. Most apps should copy hub data into a database for easy indexing and querying. 
+Hubs validate, store, and replicate account messages to other hubs. Apps run hubs to read and write to Farcaster in real-time. Hubs run on commodity hardware and are conceptually like low-level, high-performance data streams. Most apps should copy hub data into a database for easy indexing and querying. 
 
 Each hub stores the entire global state or messages created by every account on the network. The Storage Registry's max storage unit limit ensures that the size of the global state is bounded. Unlike Ethereum nodes, hubs are eventually consistent and may get messages out of order. This makes reading and writing very fast at the cost of more complexity when interpreting changes.
 

--- a/docs/protocol/concepts.md
+++ b/docs/protocol/concepts.md
@@ -28,7 +28,7 @@ Signers are [Ed25519 keys](https://en.wikipedia.org/wiki/EdDSA#Ed25519) that are
 
 ## Messages 
 
-Messages are public updates Farcaster like making a post, following someone, or adding a profile picture. The network supports many message types, and each has its own properties, requirements and semantics. Messages are stored entirely offchain on Farcaster Hubs. 
+Messages are public updates to Farcaster. Updates can be making a post, following someone, or adding a profile picture. The network supports many message types, and each has its own properties, requirements, and semantics. Messages are stored entirely offchain on Farcaster Hubs. 
 
 A message is encoded as a [protobuf](https://protobuf.dev/) and must be hashed and signed by the account's signer. Users can publish messages to Hubs as long as they have sufficient storage. Hubs check the validity of each message's signers before accepting them. 
 
@@ -36,4 +36,4 @@ A message is encoded as a [protobuf](https://protobuf.dev/) and must be hashed a
 
 Storage gives an account the right to publish messages to the network. It is rented by paying a yearly fee, similar to how space is rented on a web server. Storage is managed and tracked onchain by the StorageRegistry contract. 
 
-Storage is measured in units, and one unit grants an account the right to store a certain number of messages. Anyone can pay the StorageRegistry to rent a storage unit for an account. The price and size of each storage unit will change according to supply and demand.
+Storage is measured in units, and one unit grants an account the right to store a certain number of messages. Anyone can pay the StorageRegistry to rent a storage unit for an account. The price and size of each storage unit will vary according to supply and demand.

--- a/docs/protocol/fnames.md
+++ b/docs/protocol/fnames.md
@@ -22,8 +22,8 @@ The registry also imposes some restrictions to prevent abuse
 
 The [Fname registry](https://github.com/farcasterxyz/fname-registry) server is hosted at https://fnames.farcaster.xyz
 
-It's a simple HTTP service that's responsible for issuing and tracking fnames. All fname changes are recorded as a transfer.
-Registering an Fname is a transfer from fid 0 to the user's fid. Transferring an fname is a transfer from the user's fid to another fid. Unregistering an fname is a transfer from the user's fid to fid 0.
+It's a simple HTTP service that's responsible for issuing and tracking fnames. All Fname changes are recorded as a transfer.
+Registering an fname is a transfer from FID 0 to the user's fid. Transferring an fname is a transfer from the user's fid to another fid. Unregistering an fname is a transfer from the user's fid to fid 0.
 
 ### Get Transfer History
 

--- a/docs/protocol/fnames.md
+++ b/docs/protocol/fnames.md
@@ -9,7 +9,7 @@ Fnames have a usage policy to prevent squatting and impersonation. Users who do 
 - Names connected to public figures or entities may be reclaimed (e.g. @google)
 - Names that haven't been used for 60+ days may be reclaimed
 
-Decisions usually require human judgementand are made by the Farcaster core team. For instance, if a user registers @elon and Elon Musk wants the name, we made the decision based on whether the user:
+Decisions usually require human judgement and are made by the Farcaster core team. For instance, if a user registers @elon and Elon Musk wants the name, we made the decision based on whether the user:
 
 - Is active and creating quality content on Farcaster
 - Has a reasonable claim, like being called elon or owning the handle elsewhere


### PR DESCRIPTION
Minor grammar mods

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on minor grammar and spelling corrections in three files.  The last change should not be read but not committed. 

### Detailed summary:
- Corrected typos in Architecture.md
- Corrected typos in Concepts.md
- Corrected typos in Fnames.md

/codex The last edit is just to point out the issue of terminolgy and requesting preference or direction.  There should be a grammar list or dictionary for the site to keep current and future documentation consistent. Is that something you are interesting in? These are all minutia and not a question of "functional language" describing how processes work so should not be a big decision to merge. :-?

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->