### PR TITLE
Update Farcaster core team link

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -20,7 +20,7 @@ Farcaster is still in beta, and an invitation is required to join. If you don't 
 
 ### Who is building Farcaster?
 
-Farcaster is an MIT-licensed protocol created by a community of users and developers. The [Farcaster core team](https://github.com/orgs/farcasterxyz/teams/core/members) maintains the repository with contributions made by over 50 developers.
+Farcaster is an MIT-licensed protocol created by a community of users and developers. The [Farcaster core team](https://github.com/orgs/farcasterxyz/people) maintains the repository with contributions made by over 50 developers.
 
 ### Does Farcaster use a blockchain?
 


### PR DESCRIPTION
when you click on **Farcaster core team** it takes you to 404 page. so i upload the right link.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the links to the Farcaster core team members and fixes a line break in the file. 

### Detailed summary
- Updated the link to the Farcaster core team members in the `Who is building Farcaster?` section.
- Fixed a line break in the `Why is Farcaster invite only?` section.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->