### PR TITLE
docs: Remove 'invitation is required' from landing page

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -14,8 +14,6 @@ To learn more about Farcaster, check out the following resources:
 - [App Directory](https://www.farcaster.xyz/apps), to find new apps and utilities.
 - [Developer Portal](https://www.farcaster.xyz/devs), to find tutorials and other resources. 
 
-Farcaster is still in beta, and an invitation is required to join. If you don't have an invite, you can join the [waitlist](https://app.deform.cc/form/5ccff9d9-9435-42da-bf0f-507e13cd0597/).
-
 ## FAQ
 
 ### Who is building Farcaster?


### PR DESCRIPTION
I believe this line no longer applies?

<!-- start pr-codex -->

---

## PR-Codex overview
This PR removes a link to the developer portal and updates the FAQ section in the index.md file of the docs folder.

### Detailed summary:
- Removed the link to the Developer Portal.
- Updated the FAQ section.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->