### PR TITLE
domain Syntax Issue

### DIFF
--- a/docs/auth-kit/client/introduction.md
+++ b/docs/auth-kit/client/introduction.md
@@ -38,7 +38,7 @@ Now that your client is set up, you can use it to interact with Farcaster Auth a
 ```tsx
 const { data: { channelToken } } = await appClient.createChannel({
     siweUri: "https://example.com/login",
-    domain: "example.com";
+    domain: "example.com",
 });
 
 const status = await appClient.watchStatus({


### PR DESCRIPTION
There is a minor syntax issue in the example under "Consume actions." The semicolon after the domain property is incorrect. It should be a comma.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on correcting the syntax for the `createChannel` method in the `docs/auth-kit/client/introduction.md` file.

### Detailed summary
- Changed the syntax for the `domain` property in the `appClient.createChannel` method from a semicolon (`;`) to a comma (`,`).

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->