### PR TITLE
Typo fix Update contracts.md

### DIFF
--- a/docs/learn/architecture/contracts.md
+++ b/docs/learn/architecture/contracts.md
@@ -32,4 +32,4 @@ The Storage Registry lets accounts rent [storage](../what-is-farcaster/messages.
 
 ### Key Registry
 
-The Key Registry lets accounts issue keys to apps, so that they can publish messages on their behalf. Keys can be added or removed at any time. To add a key, an account must submit the public key of an EdDSA key pair along with a requestor signature. The requestor can be the account itself or an app that wants to operate on its behalf.
+The Key Registry lets accounts issue keys to apps, so that they can publish messages on their behalf. Keys can be added or removed at any time. To add a key, an account must submit the public key of an EdDSA key pair along with a requestor signature. The requester can be the account itself or an app that wants to operate on its behalf.


### PR DESCRIPTION
# Fix Typo in contracts.md

This pull request addresses a minor typo in the `contracts.md` file. Specifically:
- Corrected `requestor` to `requester` for consistency and accuracy.

No functional changes were made, only a documentation improvement for better clarity.

---

### Changes:
```diff
- The requestor can be the account itself or an app that wants to operate on its behalf.
+ The requester can be the account itself or an app that wants to operate on its behalf.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on correcting a typographical error in the documentation regarding the `Key Registry`. The term "requestor" has been changed to "requester" for consistency and accuracy.

### Detailed summary
- Changed "requestor" to "requester" in the description of the `Key Registry` in `docs/learn/architecture/contracts.md`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->