### PR TITLE
Fix typo Update message.md

### DIFF
--- a/docs/reference/hubble/httpapi/message.md
+++ b/docs/reference/hubble/httpapi/message.md
@@ -196,7 +196,7 @@ async fn main() {
 
     let msg_data_bytes = msg_data.write_to_bytes().unwrap();
 
-    // Calculate the blake3 hash, trucated to 20 bytes
+    // Calculate the blake3 hash, truncated to 20 bytes
     let hash = blake3::hash(&msg_data_bytes).as_bytes()[0..20].to_vec();
 
     // Construct the actual message


### PR DESCRIPTION
# Fix Typo in message.md

## Summary of Changes
- Corrected a typo: "trucated" to "truncated" in the `docs/reference/hubble/httpapi/message.md` file.

---

## Additional Notes
This is a simple documentation update with no impact on the functionality of the project.  
Please review and merge at your convenience. Thank you! 😊


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on correcting a typo in the documentation regarding the calculation of a blake3 hash.

### Detailed summary
- Changed the comment from "trucated" to "truncated" in the file `docs/reference/hubble/httpapi/message.md`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->