### PR TITLE
feat: auth address docs

### DIFF
--- a/docs/auth-kit/client/app/create-channel.md
+++ b/docs/auth-kit/client/app/create-channel.md
@@ -13,14 +13,15 @@ const channel = await appClient.createChannel({
 
 ## Parameters
 
-| Parameter        | Type     | Description                                                                   | Required | Example                                |
-| ---------------- | -------- | ----------------------------------------------------------------------------- | -------- | -------------------------------------- |
-| `siweUri`        | `string` | Login URL for your application.                                               | Yes      | `https://example.com/login`            |
-| `domain`         | `string` | Domain of your application.                                                   | Yes      | `example.com`                          |
-| `nonce`          | `string` | A custom nonce. Must be at least 8 alphanumeric characters.                   | No       | `ESsxs6MaFio7OvqWb`                    |
-| `notBefore`      | `string` | Start time at which the signature becomes valid. ISO 8601 datetime.           | No       | `2023-12-20T23:21:24.917Z`             |
-| `expirationTime` | `string` | Expiration time at which the signature is no longer valid. ISO 8601 datetime. | No       | `2023-12-20T23:21:24.917Z`             |
-| `requestId`      | `string` | A system specific ID your app can use to refer to the sign in request.        | No       | `8d0494d9-e0cf-402b-ab0a-394ac7fe07a0` |
+| Parameter           | Type      | Description                                                                                                                   | Required | Example                                |
+| ------------------- | --------- | ----------------------------------------------------------------------------------------------------------------------------- | -------- | -------------------------------------- |
+| `siweUri`           | `string`  | Login URL for your application.                                                                                               | Yes      | `https://example.com/login`            |
+| `domain`            | `string`  | Domain of your application.                                                                                                   | Yes      | `example.com`                          |
+| `nonce`             | `string`  | A custom nonce. Must be at least 8 alphanumeric characters.                                                                   | No       | `ESsxs6MaFio7OvqWb`                    |
+| `notBefore`         | `string`  | Start time at which the signature becomes valid. ISO 8601 datetime.                                                           | No       | `2023-12-20T23:21:24.917Z`             |
+| `expirationTime`    | `string`  | Expiration time at which the signature is no longer valid. ISO 8601 datetime.                                                 | No       | `2023-12-20T23:21:24.917Z`             |
+| `requestId`         | `string`  | A system specific ID your app can use to refer to the sign in request.                                                        | No       | `8d0494d9-e0cf-402b-ab0a-394ac7fe07a0` |
+| `acceptAuthAddress` | `boolean` | Whether your application accepts signatures from an [auth address](https://github.com/farcasterxyz/protocol/discussions/225). | No       | `true`                                 |
 
 ## Returns
 
@@ -40,7 +41,7 @@ const channel = await appClient.createChannel({
 | Parameter           | Description                                                                        |
 | ------------------- | ---------------------------------------------------------------------------------- |
 | `response`          | HTTP response from the Connect relay server.                                       |
-| `data.channelToken` | Connect relay channel token UUID.                                                  |
+| `data.channelToken` | Connect relay channel token.                                                       |
 | `data.url`          | Sign in With Farcaster URL to present to the user. Links to Warpcast client in v1. |
 | `data.nonce`        | Random nonce included in the Sign in With Farcaster message.                       |
 | `isError`           | True when an error has occurred.                                                   |

--- a/docs/auth-kit/client/app/status.md
+++ b/docs/auth-kit/client/app/status.md
@@ -8,7 +8,7 @@ In `'completed'` state, the response includes the generated Sign in With Farcast
 
 ```ts
 const status = await appClient.status({
-  channelToken: '210f1718-427e-46a4-99e3-2207f21f83ec',
+  channelToken: '23W59BKK',
 });
 ```
 
@@ -26,38 +26,64 @@ const status = await appClient.status({
     data: {
       state: "pending";
       nonce: string;
+      metadata: {
+        ip: string;
+        userAgent: string;
+      };
+      acceptAuthAddress: boolean;
     } | {
       state: "completed";
       nonce: string;
       url: string;
-      message: string;
-      signature: `0x${string}`;
-      fid: number;
+      message?: string;
+      signature?: `0x${string}`;
+      authMethod?: "custody" | "authAddress";
+      fid?: number;
       username?: string;
       bio?: string;
       displayName?: string;
       pfpUrl?: string;
-      verifications?: Hex[];
+      verifications?: string[];
       custody?: Hex;
+      signatureParams: {
+        siweUri: string;
+        domain: string;
+        nonce?: string;
+        notBefore?: string;
+        expirationTime?: string;
+        requestId?: string;
+        redirectUrl?: string;
+      };
+      metadata: {
+        ip: string;
+        userAgent: string;
+      };
+      acceptAuthAddress: boolean;
     }
     isError: boolean
     error: Error
 }
 ```
 
-| Parameter            | Description                                                                                                                        |
-| -------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
-| `response`           | HTTP response from the Connect relay server.                                                                                       |
-| `data.state`         | Status of the sign in request, either `"pending"` or `"complete"`                                                                  |
-| `data.nonce`         | Random nonce used in the SIWE message. If you don't provide a custom nonce as an argument to the hook, you should read this value. |
-| `data.message`       | The generated SIWE message.                                                                                                        |
-| `data.signature`     | Hex signature produced by the user's Warpcast wallet.                                                                              |
-| `data.fid`           | User's Farcaster ID.                                                                                                               |
-| `data.username`      | User's Farcaster username.                                                                                                         |
-| `data.bio`           | User's Farcaster bio.                                                                                                              |
-| `data.displayName`   | User's Farcaster display name.                                                                                                     |
-| `data.pfpUrl`        | User's Farcaster profile picture URL.                                                                                              |
-| `data.custody`       | User's FID custody address.                                                                                                        |
-| `data.verifications` | List of user's verified addresses.                                                                                                 |
-| `isError`            | True when an error has occurred.                                                                                                   |
-| `error`              | `Error` instance.                                                                                                                  |
+| Parameter                 | Description                                                                                                                        |
+| ------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| `response`                | HTTP response from the Connect relay server.                                                                                       |
+| `data.state`              | Status of the sign in request, either `"pending"` or `"completed"`                                                                 |
+| `data.nonce`              | Random nonce used in the SIWE message. If you don't provide a custom nonce as an argument to the hook, you should read this value. |
+| `data.url`                | URL of the application.                                                                                                            |
+| `data.message`            | The generated SIWE message.                                                                                                        |
+| `data.signature`          | Hex signature produced by the user's Warpcast wallet.                                                                              |
+| `data.authMethod`         | Auth method used to sign the message. Either `"custody"` or `"authAddress"`.                                                       |
+| `data.fid`                | User's Farcaster ID.                                                                                                               |
+| `data.username`           | User's Farcaster username.                                                                                                         |
+| `data.bio`                | User's Farcaster bio.                                                                                                              |
+| `data.displayName`        | User's Farcaster display name.                                                                                                     |
+| `data.pfpUrl`             | User's Farcaster profile picture URL.                                                                                              |
+| `data.custody`            | User's FID custody address.                                                                                                        |
+| `data.verifications`      | List of user's verified addresses.                                                                                                 |
+| `data.signatureParams`    | SIWF message parameters.                                                                                                           |
+| `data.metadata.ip`        | IP address of client request.                                                                                                      |
+| `data.metadata.userAgent` | User agent of client request.                                                                                                      |
+| `data.acceptAuthAddress`  | `true` if requesting application accepts auth address signatures.                                                                  |
+| `isError`                 | True when an error has occurred.                                                                                                   |
+| `error`                   | `Error` instance.                                                                                                                  |

--- a/docs/auth-kit/client/app/verify-sign-in-message.md
+++ b/docs/auth-kit/client/app/verify-sign-in-message.md
@@ -10,17 +10,19 @@ const { data, success, fid } = await appClient.verifySignInMessage({
   domain: 'example.com',
   message: 'example.com wants you to sign in with your Ethereum account…',
   signature: '0x9335c3055d47780411a3fdabad293c68c84ea350a11794cd11fd51b…',
+  acceptAuthAddress: true,
 });
 ```
 
 ## Parameters
 
-| Parameter   | Type                      | Description                                                                                                                                                                                  | Required |
-| ----------- | ------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- |
-| `domain`    | `string`                  | Domain of your application. Must match the domain in the provided SIWF message.                                                                                                              | Yes      |
-| `nonce`     | `string`                  | A custom nonce. Must match the nonce in the provided SIWF message.                                                                                                                           | Yes      |
-| `message`   | `string` or `SiweMessage` | The Sign in With Farcaster message to verify. This may be either a string or a parsed `SiweMessage`. Your app should read this value from the Connect channel once the request is completed. | Yes      |
-| `signature` | `Hex`                     | Signature provided by the user's Farcaster wallet. Your app should read this from the Connect channel once the request is completed.                                                         | Yes      |
+| Parameter           | Type                      | Description                                                                                                                                                                                  | Required |
+| ------------------- | ------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- |
+| `domain`            | `string`                  | Domain of your application. Must match the domain in the provided SIWF message.                                                                                                              | Yes      |
+| `nonce`             | `string`                  | A custom nonce. Must match the nonce in the provided SIWF message.                                                                                                                           | Yes      |
+| `message`           | `string` or `SiweMessage` | The Sign in With Farcaster message to verify. This may be either a string or a parsed `SiweMessage`. Your app should read this value from the Connect channel once the request is completed. | Yes      |
+| `signature`         | `Hex`                     | Signature provided by the user's Farcaster wallet. Your app should read this from the Connect channel once the request is completed.                                                         | Yes      |
+| `acceptAuthAddress` | `boolean`                 | Pass `true` to accept an [auth address](https://github.com/farcasterxyz/protocol/discussions/225) signature in addition to a custody address signature.                                      | No       |
 
 ## Returns
 

--- a/docs/auth-kit/client/app/watch-status.md
+++ b/docs/auth-kit/client/app/watch-status.md
@@ -31,36 +31,66 @@ const status = await appClient.watchStatus({
 {
     response: Response
     data: {
-        state: 'pending' | 'completed'
-        nonce: string
-        message?: string
-        signature?: Hex
-        fid?: number
-        username?: string
-        bio?: string
-        displayName?: string
-        pfpUrl?: string
-        custody?: Hex;
-        verifications?: Hex[];
+      state: "pending";
+      nonce: string;
+      metadata: {
+        ip: string;
+        userAgent: string;
+      };
+      acceptAuthAddress: boolean;
+    } | {
+      state: "completed";
+      nonce: string;
+      url: string;
+      message?: string;
+      signature?: `0x${string}`;
+      authMethod?: "custody" | "authAddress";
+      fid?: number;
+      username?: string;
+      bio?: string;
+      displayName?: string;
+      pfpUrl?: string;
+      verifications?: string[];
+      custody?: Hex;
+      signatureParams: {
+        siweUri: string;
+        domain: string;
+        nonce?: string;
+        notBefore?: string;
+        expirationTime?: string;
+        requestId?: string;
+        redirectUrl?: string;
+      };
+      metadata: {
+        ip: string;
+        userAgent: string;
+      };
+      acceptAuthAddress: boolean;
     }
     isError: boolean
     error: Error
 }
 ```
 
-| Parameter            | Description                                                                                                                        |
-| -------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
-| `response`           | HTTP response from the Connect relay server.                                                                                       |
-| `data.state`         | Status of the sign in request, either `"pending"` or `"complete"`                                                                  |
-| `data.nonce`         | Random nonce used in the SIWE message. If you don't provide a custom nonce as an argument to the hook, you should read this value. |
-| `data.message`       | The generated SIWE message.                                                                                                        |
-| `data.signature`     | Hex signature produced by the user's Warpcast wallet.                                                                              |
-| `data.fid`           | User's Farcaster ID.                                                                                                               |
-| `data.username`      | User's Farcaster username.                                                                                                         |
-| `data.bio`           | User's Farcaster bio.                                                                                                              |
-| `data.displayName`   | User's Farcaster display name.                                                                                                     |
-| `data.pfpUrl`        | User's Farcaster profile picture URL.                                                                                              |
-| `data.custody`       | User's FID custody address.                                                                                                        |
-| `data.verifications` | List of user's verified addresses.                                                                                                 |
-| `isError`            | True when an error has occurred.                                                                                                   |
-| `error`              | `Error` instance.                                                                                                                  |
+| Parameter                 | Description                                                                                                            |
+| ------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| `response`                | HTTP response from the Connect relay server.                                                                           |
+| `data.state`              | Status of the sign in request, either `"pending"` or `"completed"`                                                     |
+| `data.nonce`              | Random nonce used in the SIWE message. If you don't provide a custom nonce as an argument, you should read this value. |
+| `data.url`                | URL of the application.                                                                                                |
+| `data.message`            | The generated SIWE message.                                                                                            |
+| `data.signature`          | Hex signature produced by the user's Warpcast wallet.                                                                  |
+| `data.authMethod`         | Auth method used to sign the message. Either `"custody"` or `"authAddress"`.                                           |
+| `data.fid`                | User's Farcaster ID.                                                                                                   |
+| `data.username`           | User's Farcaster username.                                                                                             |
+| `data.bio`                | User's Farcaster bio.                                                                                                  |
+| `data.displayName`        | User's Farcaster display name.                                                                                         |
+| `data.pfpUrl`             | User's Farcaster profile picture URL.                                                                                  |
+| `data.custody`            | User's FID custody address.                                                                                            |
+| `data.verifications`      | List of user's verified addresses.                                                                                     |
+| `data.signatureParams`    | SIWF message parameters.                                                                                               |
+| `data.metadata.ip`        | IP address of client request.                                                                                          |
+| `data.metadata.userAgent` | User agent of client request.                                                                                          |
+| `data.acceptAuthAddress`  | `true` if requesting application accepts auth address signatures.                                                      |
+| `isError`                 | True when an error has occurred.                                                                                       |
+| `error`                   | `Error` instance.                                                                                                      |

--- a/docs/auth-kit/client/wallet/authenticate.md
+++ b/docs/auth-kit/client/wallet/authenticate.md
@@ -6,6 +6,7 @@ Submit a Sign In With Farcaster message, user signature, and profile data to the
 const params = await walletClient.authenticate({
   message: 'example.com wants you to sign in with your Ethereum account…',
   signature: '0x9335c3055d47780411a3fdabad293c68c84ea350a11794cdc811fd5…',
+  authMethod: 'authAddress',
   fid: 1,
   username: 'alice',
   bio: "I'm a little teapot who didn't fill out my bio",
@@ -21,8 +22,8 @@ const params = await walletClient.authenticate({
 | `authKey`      | `string` | Farcaster Auth API key. Farcaster Auth v1 restricts calls to `/authenticate` to Warpcast. | Yes      |
 | `channelToken` | `string` | Farcaster Auth channel token.                                                             | Yes      |
 | `message`      | `string` | The Sign in With Farcaster message produced by your wallet app and signed by the user.    | Yes      |
-| `message`      | `string` | The Sign in With Farcaster message produced by your wallet app and signed by the user.    | Yes      |
 | `signature`    | `Hex`    | SIWE signature created by the wallet user's account.                                      | Yes      |
+| `authMethod`   | `string` | Method used to sign the SIWF message. Either `"custody"` or `"authAddress"`.              | Yes      |
 | `fid`          | `number` | Wallet user's fid.                                                                        | Yes      |
 | `username`     | `string` | Wallet user's Farcaster username.                                                         | Yes      |
 | `bio`          | `string` | Wallet user's bio.                                                                        | Yes      |

--- a/docs/auth-kit/client/wallet/parse-sign-in-uri.md
+++ b/docs/auth-kit/client/wallet/parse-sign-in-uri.md
@@ -8,7 +8,7 @@ Returns an error if URI is invalid.
 
 ```ts
 const params = walletClient.parseSignInURI({
-  uri: 'farcaster://connect?channelToken=76be6229-bdf7-4ad2-930a-540fb2de1e08&nonce=ESsxs6MaFio7OvqWb&siweUri=https%3A%2F%2Fexample.com%2Flogin&domain=example.com',
+  uri: 'farcaster://connect?channelToken=23W59BKK&nonce=ESsxs6MaFio7OvqWb&siweUri=https%3A%2F%2Fexample.com%2Flogin&domain=example.com',
 });
 ```
 
@@ -38,7 +38,7 @@ const params = walletClient.parseSignInURI({
 
 | Parameter               | Description                                                       |
 | ----------------------- | ----------------------------------------------------------------- |
-| `channelToken`          | Connect relay channel token UUID.                                 |
+| `channelToken`          | Connect relay channel token.                                      |
 | `params.uri`            | Login URI of the relying connected app.                           |
 | `params.domain`         | Domain of the relying app.                                        |
 | `params.nonce`          | Random nonce provided by the relying app.                         |


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on updates to the authentication process in the `auth-kit` client, including changes to URIs, parameters, and the introduction of new fields for handling authentication methods and metadata.

### Detailed summary
- Updated the `uri` in `parseSignInURI` to a new channel token.
- Revised the description of `channelToken` in `parseSignInURI` documentation.
- Added `authMethod` parameter in `authenticate` with description.
- Introduced `acceptAuthAddress` boolean in multiple files to specify acceptance of auth address signatures.
- Enhanced metadata structure to include `ip` and `userAgent` in various responses.
- Removed duplicate `message` entry in `authenticate` documentation.
- Updated `status` method to use a new `channelToken`.
- Modified return types in `watch-status` and `status` methods to include `authMethod` and `signatureParams`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->