### PR TITLE
add embed Farcaster Feed SDKs

### DIFF
--- a/docs/developers/resources.md
+++ b/docs/developers/resources.md
@@ -25,6 +25,8 @@ Resources are often from third parties and are not reviewed. Use them at your ow
 ### Apps
 
 - [farcaster kit](https://www.farcasterkit.com/) - react hooks for building Farcaster apps.
+- [getembed.ai React Components](https://docs.getembed.ai/docs/render-a-feed-in-a-farcaster-mini-app-using-react) - ready made react components to render Farcaster feeds in your apps
+- [getembed.ai Typescript SDK](https://docs.getembed.ai/) - functions to get feeds, recommendations and AI labels for Farcaster users (FIDs)
 
 ### Snapchain
 


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the `resources.md` documentation to replace outdated references with new resources related to `getembed.ai`, enhancing the information available for developers building Farcaster apps.

### Detailed summary
- Replaced the entry for `farcaster kit` with `getembed.ai React Components`, providing a link to documentation for ready-made components.
- Added a new entry for `getembed.ai Typescript SDK`, detailing functions for obtaining feeds, recommendations, and AI labels for Farcaster users (FIDs).

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->