### PR TITLE
Fix typos and formatting in documentation

### DIFF
--- a/docs/developers/guides/writing/casts.md
+++ b/docs/developers/guides/writing/casts.md
@@ -83,7 +83,7 @@ const castWithEmojiAndMentions = await makeCastAdd(
 
 A cast can be a reply to another cast, URL or NFT. A reply to another cast is treated as a thread, while a reply to a URL or NFT can be treated as a comment or a [channel](#channels).
 
-The optional parentUrl property can be set to a URL or to an fid-hash value of the cast being replied to, as shown in th example below. See [FIP-2](https://github.com/farcasterxyz/protocol/discussions/71) for more details on reply types.
+The optional parentUrl property can be set to a URL or to an fid-hash value of the cast being replied to, as shown in the example below. See [FIP-2](https://github.com/farcasterxyz/protocol/discussions/71) for more details on reply types.
 
 ```typescript
 /**

--- a/docs/developers/guides/writing/messages.md
+++ b/docs/developers/guides/writing/messages.md
@@ -67,7 +67,7 @@ const castRemove = await makeCastRemove(
 );
 ```
 
-To create casts with embeds, mentions, channels emoji, see the [casts](../writing/casts.md) tutorial.
+To create casts with embeds, mentions, channels, and emoji, see the [casts](../writing/casts.md) tutorial.
 
 ## Reactions
 

--- a/docs/developers/guides/writing/verify-address.md
+++ b/docs/developers/guides/writing/verify-address.md
@@ -4,7 +4,7 @@
 
 - Write access to a Snapchain instance
 - Private key of an account key registered to an fid
-- An Ethereum provider URL for OP Mainnet (e.g. via [Alchemy](https://www.alchemy.com/),[Infura](https://www.infura.io/) or [QuickNode](https://www.quicknode.com/)).
+- An Ethereum provider URL for OP Mainnet (e.g. via [Alchemy](https://www.alchemy.com/), [Infura](https://www.infura.io/) or [QuickNode](https://www.quicknode.com/)).
 
 :::
 

--- a/docs/developers/index.md
+++ b/docs/developers/index.md
@@ -17,8 +17,8 @@ Learn how to build mini apps (previously called Frames) that run inside a Farcas
 
 Make it easy for users to sign in to your app with their Farcaster account.
 
-- [Examples](/auth-kit/examples.md) - see Sign in with Farcaster (SIWF) in action
-- [AuthKit](/auth-kit/installation.md) - a React toolkit to integrate SIWF
+- [Examples](/auth-kit/examples) - see Sign in with Farcaster (SIWF) in action
+- [AuthKit](/auth-kit/installation) - a React toolkit to integrate SIWF
 - [FIP-11](https://github.com/farcasterxyz/protocol/discussions/110) - the formal standard for SIWF
 
 ## Analyze Farcaster data

--- a/docs/developers/siwf/index.md
+++ b/docs/developers/siwf/index.md
@@ -18,7 +18,7 @@ a streamlined onboarding experience and social-powered features.
 3. Receive and verify a signature from Farcaster.
 4. Show the logged in user's profile picture and username.
 
-![Sign In with Farcaste demo](./siwf_demo.avifs)
+![Sign In with Farcaster demo](./siwf_demo.avifs)
 
 ## Next Steps
 

--- a/docs/reference/farcaster/api.md
+++ b/docs/reference/farcaster/api.md
@@ -908,7 +908,7 @@ curl -X DELETE \
 
 `GET /fc/account-verifications`
 
-### This endpoint is not stable (beta) and likely to have breaking changes in the future or get depracated.
+### This endpoint is not stable (beta) and likely to have breaking changes in the future or get deprecated.
 
 List of account verifications attested by the Farcaster client. Ordered by the time when the verification occurred, descending. Paginated. Not authenticated.
 


### PR DESCRIPTION
Fixed multiple documentation issues:

**Typos:**
1. **casts.md**: "th example" → "the example"
2. **siwf/index.md**: "Farcaste" → "Farcaster"
3. **warpcast/api.md**: "depracated" → "deprecated"
4. **messages.md**: "channels emoji" → "channels, and emoji"

**Formatting:**
5. **verify-address.md**: Added missing space after comma in link list

**Link Consistency:**
6. **developers/index.md**: Removed .md extensions from internal links for consistency

All simple text corrections to improve documentation quality.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving documentation clarity and correcting minor typographical errors across various Markdown files related to the Farcaster project.

### Detailed summary
- Corrected the demo name from `Sign In with Farcaste` to `Sign In with Farcaster`.
- Added a comma in a sentence about creating casts.
- Fixed the spelling of `deprecated`.
- Removed an extra line break in the Ethereum provider URL description.
- Updated links to remove `.md` extensions for consistency.
- Corrected the spelling of `th example` to `the example`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->