### PR TITLE
put the snap link back into the header

### DIFF
--- a/src/lib/nav-config.ts
+++ b/src/lib/nav-config.ts
@@ -32,8 +32,7 @@ export const TOP_NAV: NavLink[] = [
   { text: "Learn", link: "/learn/" },
   { text: "Build apps", link: "/developers/" },
   { text: "AuthKit", link: "/auth-kit/" },
-  // TODO: Add back when Snap docs go public
-  // { text: "Snap", link: "/snap/" },
+  { text: "Snap", link: "/snap/" },
   { text: "Reference", link: "/reference/" },
   {
     text: "Snapchain",


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on updating the navigation configuration by uncommenting the `Snap` entry, making it publicly accessible in the navigation menu.

### Detailed summary
- Uncommented the `Snap` entry in the navigation configuration.
- The `Snap` entry now includes the text "Snap" and the link "/snap/".
- Other entries remain unchanged, including "Build apps," "AuthKit," and "Reference."

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->